### PR TITLE
Change double to single quotes in export command

### DIFF
--- a/rmf_inorbit_demos/README.md
+++ b/rmf_inorbit_demos/README.md
@@ -32,7 +32,7 @@ git clone https://github.com/inorbit-ai/rmf_inorbit_examples
 - Add the API key you obtained from InOrbit as an environment variable:
 
 ```
-echo “export INORBIT_API_KEY=<your api key>” >> ~/.bashrc
+echo 'export INORBIT_API_KEY=<your api key>' >> ~/.bashrc
 source ~/.bashrc
 # If in a docker environment, remember to commit the changes at the exit trap when exiting the container
 ```


### PR DESCRIPTION
There was an error in the setup instructions. The `echo` command for adding the `export` command for the API key in the `~/.bashrc` file had double quotes, that are not removed in the command output. Single quotes add the whole line to the file without copying the quote characters as well.
This error lead to users getting stuck in the setup process.