### PR TITLE
Fix missing word in the setup configuration

### DIFF
--- a/rmf_inorbit_demos/README.md
+++ b/rmf_inorbit_demos/README.md
@@ -32,7 +32,7 @@ git clone https://github.com/inorbit-ai/rmf_inorbit_examples
 - Add the API key you obtained from InOrbit as an environment variable:
 
 ```
-echo 'export INORBIT_API_KEY=<your api key>' >> ~/.bashrc
+echo "export INORBIT_API_KEY=<your api key>" >> ~/.bashrc
 source ~/.bashrc
 # If in a docker environment, remember to commit the changes at the exit trap when exiting the container
 ```

--- a/rmf_inorbit_template/README.md
+++ b/rmf_inorbit_template/README.md
@@ -22,7 +22,7 @@ Go to [ros_amr_interop/rmf_inorbit_fleet_adapter](https://github.com/inorbit-ai/
 
 ```
 # From inside the container:
-echo  “INORBIT_API_KEY=<your api key>” >> ~/.bashrc
+echo "export INORBIT_API_KEY=<your api key>" >> ~/.bashrc
 source ~/.bashrc
 
 # If in a docker environment, remember to commit the changes at the exit trap when exiting the container


### PR DESCRIPTION
`export` was missing when setting up an environment variable for the template package